### PR TITLE
Make build-info provider-agnostic for Cloudflare Pages previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,16 +30,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: Generate build info
-        run: |
-          mkdir -p _data
-          {
-            echo "sha: ${GITHUB_SHA}"
-            echo "ref: ${GITHUB_REF}"
-            echo "run_id: ${GITHUB_RUN_ID}"
-            echo "run_number: ${GITHUB_RUN_NUMBER}"
-            echo "time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          } > _data/build.yml
-          cat _data/build.yml
+        run: ./script/build-info
       - name: Build site
         env:
           JEKYLL_ENV: production

--- a/_config.yml
+++ b/_config.yml
@@ -126,6 +126,7 @@ exclude:
   - devbox.lock
   - .devbox
   - .ruby-version
+  - script
   - CONTRIBUTING.md
   - LICENSE
   - README.md

--- a/script/build-info
+++ b/script/build-info
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Writes _data/build.yml with SHA, ref, and build time.
+# Detects GitHub Actions, Cloudflare Pages, or falls back to local git.
+set -euo pipefail
+
+mkdir -p _data
+
+if [ -n "${GITHUB_SHA:-}" ]; then
+  sha=$GITHUB_SHA
+  ref=$GITHUB_REF
+  run_id=$GITHUB_RUN_ID
+  run_number=$GITHUB_RUN_NUMBER
+  provider=github-actions
+elif [ -n "${CF_PAGES_COMMIT_SHA:-}" ]; then
+  sha=$CF_PAGES_COMMIT_SHA
+  ref=refs/heads/$CF_PAGES_BRANCH
+  run_id=${CF_PAGES_URL:-}
+  run_number=
+  provider=cloudflare-pages
+else
+  sha=$(git rev-parse HEAD 2>/dev/null || echo unknown)
+  ref=$(git symbolic-ref HEAD 2>/dev/null || echo unknown)
+  run_id=
+  run_number=
+  provider=local
+fi
+
+cat > _data/build.yml <<EOF
+sha: $sha
+ref: $ref
+run_id: $run_id
+run_number: $run_number
+provider: $provider
+time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+cat _data/build.yml


### PR DESCRIPTION
## Summary
- Extract the `_data/build.yml` generation from `deploy.yml` into `script/build-info` so the same Jekyll build can run on either GitHub Actions or Cloudflare Pages.
- The script auto-detects `GITHUB_SHA` / `CF_PAGES_COMMIT_SHA` / local git and writes a consistent `_data/build.yml` (including a new `provider` field).
- Workflow now just calls `./script/build-info`; `_config.yml` excludes `script/` from Jekyll's output.

This is the repo-side prerequisite for adding Cloudflare Pages as a preview-deploy provider. The dashboard configuration (connecting the repo, setting build command + env vars) is the next step and happens outside the repo.

## Test plan
- [x] `./script/build-info` locally writes correct YAML with `provider: local`
- [x] `bundle exec jekyll build` after the script succeeds; `script/` doesn't leak into `_site/`
- [ ] Existing GitHub Actions deploy on this PR still produces the same `build.yml` shape and tag (`provider: github-actions`)
- [ ] After dashboard setup, a Cloudflare Pages preview build on this branch produces a working preview URL with the build tag rendering as `cloudflare-pages`