### PR TITLE
Shrink hero photo on small screens

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -100,6 +100,13 @@
     box-shadow: 0 0 0 4px var(--accent-glow);
 
     img { width: 100%; height: 100%; object-fit: cover; display: block; }
+
+    @media (max-width: 640px) {
+      width: 120px;
+      height: 120px;
+      justify-self: center;
+      box-shadow: 0 0 0 3px var(--accent-glow);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- A real iPhone 13 screenshot showed the 180x180 hero photo dominating the visible viewport and sitting orphaned at bottom-right.
- Below 640px: photo drops to **120x120**, `justify-self: center`, glow halo trimmed from 4px to 3px.

## Test plan
- [ ] Cloudflare Pages preview at `https://mobile-polish.<project>.pages.dev/` once CF Pages is set up
- [ ] Verify on actual iPhone (not just headless Chromium) that the photo no longer dominates the hero
- [ ] Confirm desktop (>=640px) is unchanged