### PR TITLE
Inline profile photo next to name on mobile

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -8,7 +8,13 @@ layout: default
   </div>
 
   <div class="hero-grid">
-    <div>
+    {% if page.profile and page.profile.image %}
+    <div class="hero-photo">
+      <img src="{{ page.profile.image | prepend: '/assets/img/' | relative_url }}" alt="{{ site.first_name }} {{ site.last_name }}">
+    </div>
+    {% endif %}
+
+    <div class="hero-text">
       <h1 class="hero-headline">
         {{ site.first_name }} <span class="accent">{{ site.last_name }}</span>
         <span class="cursor"></span>
@@ -23,12 +29,6 @@ layout: default
       <p class="hero-motto">&mdash; <em>{{ site.contact_note | strip_newlines | strip }}</em></p>
       {% endif %}
     </div>
-
-    {% if page.profile and page.profile.image %}
-    <div class="hero-photo">
-      <img src="{{ page.profile.image | prepend: '/assets/img/' | relative_url }}" alt="{{ site.first_name }} {{ site.last_name }}">
-    </div>
-    {% endif %}
   </div>
 </section>
 

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -80,13 +80,16 @@
   }
 
   .hero-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1.25rem;
-    align-items: start;
-
+    // Desktop: photo on the right column. Photo comes first in DOM so it
+    // can float-wrap on mobile; on desktop we put it back via grid order.
     @media (min-width: 640px) {
+      display: grid;
       grid-template-columns: 1fr auto;
+      gap: 1.25rem;
+      align-items: start;
+
+      .hero-photo { order: 2; }
+      .hero-text  { order: 1; }
     }
   }
 
@@ -101,11 +104,30 @@
 
     img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
+    // Mobile: small floated avatar so the headline wraps next to it.
     @media (max-width: 640px) {
-      width: 120px;
-      height: 120px;
-      justify-self: center;
-      box-shadow: 0 0 0 3px var(--accent-glow);
+      float: left;
+      width: 64px;
+      height: 64px;
+      margin: 0.2rem 0.9rem 0.4rem 0;
+      box-shadow: 0 0 0 2px var(--accent-glow);
+      justify-self: auto;
+    }
+  }
+
+  .hero-text::after {
+    // Clear the float so frames below the hero don't get tucked under the
+    // photo when the text is shorter than the avatar.
+    content: "";
+    display: block;
+    clear: both;
+  }
+
+  .hero-headline {
+    // Shrink slightly on small screens so 'Giovanni Liboni' doesn't wrap
+    // immediately next to the inline avatar.
+    @media (max-width: 480px) {
+      font-size: 1.45rem;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Below 640px: photo shrinks to **64x64** and floats left so 'Giovanni Liboni' wraps to its right (Twitter-bio style).
- Above 640px: unchanged — 180x180 photo on the right column.
- HTML reorder puts `.hero-photo` before `.hero-text` so the mobile float positions correctly; grid `order` reinstates the desktop layout.

## Test plan
- [ ] Real iPhone preview (the previous fix passed headless but failed on device)
- [ ] Desktop unchanged
- [ ] Frames below the hero (`/news` etc) aren't tucked under the avatar (clear: both safeguard)