### PR TITLE
Match news layout to selected-work entries

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -144,7 +144,8 @@
   50% { opacity: 0; }
 }
 
-// News list
+// News list — same shape as a publication entry: inline date at the top
+// in accent color, body flows below as a block.
 
 .news {
   list-style: none;
@@ -152,21 +153,28 @@
   padding: 0;
 
   li {
-    display: grid;
-    grid-template-columns: 6.5rem 1fr;
-    gap: 1rem;
-    padding: 0.6rem 0;
+    padding: 0.9rem 0;
     border-bottom: 1px dashed var(--fg-faint);
 
     &:last-child { border-bottom: 0; }
 
     .date {
-      color: var(--fg-mute);
+      display: inline-block;
+      color: var(--accent);
+      font-variant-numeric: tabular-nums;
+      margin-right: 0.5rem;
       font-size: 0.85rem;
-      &::before { content: "› "; color: var(--accent); }
     }
 
-    .news-body { color: var(--fg); }
+    .news-body {
+      display: block;
+      color: var(--fg);
+      margin-top: 0.15rem;
+
+      // jekyll-emoji wraps inline content in <p>; flatten the top margin
+      // so the body sits flush under the date.
+      > p:first-child { margin-top: 0; }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
The two-column grid (`date | body`, fixed 6.5rem column) was squeezing news bodies on narrow phones. Now news items use the same shape as `.pub-entry`: inline date in accent color at the top, body block flowing below.

- `li` padding matches `.pub-entry` (0.9rem 0)
- `.date` is inline-block, accent color, tabular-nums, no `> ` prefix
- `.news-body` is block; first `<p>` top margin reset so inline items sit flush

## Test plan
- [ ] Mobile: news entries no longer squeezed; date sits on top, body wraps full width
- [ ] Desktop: same visual rhythm as the publications below it