### PR TITLE
Add /spare-time section to the about page

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -32,6 +32,12 @@ layout: default
   </div>
 </section>
 
+{% if page.spare_time %}
+<section class="frame" data-label="/spare-time">
+  {{ page.spare_time | markdownify }}
+</section>
+{% endif %}
+
 {% if page.news and site.news %}
 <section class="frame" data-label="/news">
   {% include news.html %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -11,6 +11,13 @@ profile:
 news: true
 selected_papers: true
 social: true
+
+spare_time: |
+  Outside the day job I run a small home lab and self-host most of
+  the services I depend on. Home automation is the rabbit hole I keep
+  climbing back into — [Home Assistant](https://www.home-assistant.io/)
+  is the centerpiece — and I tend to say yes when a project calls
+  for one more Raspberry Pi.
 ---
 
 Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. Background in embedded and cyber-physical systems — the topic of my Ph.D. — and a soft spot for everything that sits between the edge and the cloud.


### PR DESCRIPTION
## Summary
Adds a `/spare-time` framed section between the hero and `/news`. Content lives in a `spare_time:` front-matter key on `_pages/about.md` (markdownified), so future edits don't touch templates.

Copy:
> Outside the day job I run a small home lab and self-host most of the services I depend on. Home automation is the rabbit hole I keep climbing back into — [Home Assistant](https://www.home-assistant.io/) is the centerpiece — and I tend to say yes when a project calls for one more Raspberry Pi.

## Test plan
- [x] iPhone 13 (390px) — section reads cleanly inside the framed box
- [x] Desktop (1024px) — paragraph wraps naturally, same rhythm as other frames
- [ ] Real device sanity check after merge