### PR TITLE
Add Playwright visual smoke tests on PRs

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,0 +1,68 @@
+name: Visual
+
+on:
+  pull_request:
+    branches:
+      - source
+
+permissions:
+  contents: read
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build site
+        env:
+          JEKYLL_ENV: production
+          PAGES_REPO_NWO: ${{ github.repository }}
+        run: |
+          ./script/build-info
+          bundle exec jekyll build
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tests/package-lock.json
+
+      - name: Install Playwright + Chromium
+        working-directory: tests
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Serve built site
+        run: |
+          python3 -m http.server 4000 --directory _site &
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            curl -fsS http://127.0.0.1:4000/ > /dev/null && break
+            sleep 1
+          done
+
+      - name: Run visual tests
+        working-directory: tests
+        env:
+          SITE_URL: http://127.0.0.1:4000
+        run: npm test
+
+      - name: Upload screenshots
+        if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: tests/screenshots/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ _data/build.yml
 !devbox.json
 !devbox.lock
 
+# Override global gitignore: track the npm lockfile under tests/ so
+# CI's `npm ci` is reproducible.
+!tests/package-lock.json
+

--- a/_config.yml
+++ b/_config.yml
@@ -127,6 +127,7 @@ exclude:
   - .devbox
   - .ruby-version
   - script
+  - tests
   - CONTRIBUTING.md
   - LICENSE
   - README.md

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.2/.schema/devbox.schema.json",
   "packages": [
-    "ruby@3.3"
+    "ruby@3.3",
+    "playwright@latest",
+    "nodejs_22@latest"
   ],
   "shell": {
     "scripts": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -5,6 +5,103 @@
       "last_modified": "2026-05-03T16:35:46Z",
       "resolved": "github:NixOS/nixpkgs/73c703c22422b8951895a960959dbbaca7296492?lastModified=1777826146&narHash=sha256-wQ%2FiN5Zp5VIa3ebBibijPnLyKhor%2BxEbDy4d0goa9Zs%3D"
     },
+    "nodejs_22@latest": {
+      "last_modified": "2026-04-23T13:07:47Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#nodejs_22",
+      "source": "devbox-search",
+      "version": "22.22.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0zb2cr3b9xlancr6s938s73pxfcbzji2-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/0zb2cr3b9xlancr6s938s73pxfcbzji2-nodejs-22.22.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2axvilfkmlz8wfa9zimidv5l1cydi4kc-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/2axvilfkmlz8wfa9zimidv5l1cydi4kc-nodejs-22.22.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5b95ias241mw7bp4bindlc5xxn66phjy-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5b95ias241mw7bp4bindlc5xxn66phjy-nodejs-22.22.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6x6v11xjf0psckgqmyhfyhw9bdma0rn6-nodejs-22.22.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6x6v11xjf0psckgqmyhfyhw9bdma0rn6-nodejs-22.22.2"
+        }
+      }
+    },
+    "playwright@latest": {
+      "last_modified": "2026-04-30T11:26:30Z",
+      "resolved": "github:NixOS/nixpkgs/7aaa00e7cc9be6c316cb5f6617bd740dd435c59d#playwright",
+      "source": "devbox-search",
+      "version": "1.59.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ryrbklwx4fm57djibvxz9skvc8nm1r1d-playwright-core-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ryrbklwx4fm57djibvxz9skvc8nm1r1d-playwright-core-1.59.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kzhra5kizi6rsmlnlk0m0ayynlw7cixm-playwright-core-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kzhra5kizi6rsmlnlk0m0ayynlw7cixm-playwright-core-1.59.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/25k0vryiwd4l94pwf7ryzq14z31063s3-playwright-core-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/25k0vryiwd4l94pwf7ryzq14z31063s3-playwright-core-1.59.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jzdig02pgpjxqh2ghpvf4ba2zki9vfka-playwright-core-1.59.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/jzdig02pgpjxqh2ghpvf4ba2zki9vfka-playwright-core-1.59.1"
+        }
+      }
+    },
     "ruby@3.3": {
       "last_modified": "2026-01-23T17:20:52Z",
       "plugin_version": "0.0.2",

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+screenshots

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "visual-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "visual-tests",
+      "dependencies": {
+        "playwright": "^1.59.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "visual-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node visual.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.59.0"
+  }
+}

--- a/tests/visual.mjs
+++ b/tests/visual.mjs
@@ -1,0 +1,62 @@
+// Visual smoke test: visit each route at desktop + mobile viewports,
+// take full-page screenshots, and fail if anything 404s or throws a
+// console error. Screenshots land in tests/screenshots/ and the
+// workflow uploads them as a build artifact.
+
+import { chromium, devices } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+
+const BASE = process.env.SITE_URL || 'http://127.0.0.1:4000';
+
+const routes = ['/', '/projects/', '/publications/'];
+
+const viewports = [
+  ['iphone-se', { ...devices['iPhone SE'] }],
+  ['iphone-13', { ...devices['iPhone 13'] }],
+  ['desktop',   { viewport: { width: 1280, height: 900 } }],
+];
+
+const outDir = new URL('./screenshots/', import.meta.url).pathname;
+await mkdir(outDir, { recursive: true });
+
+const browser = await chromium.launch();
+let failed = 0;
+
+for (const [vpName, vpOpts] of viewports) {
+  const ctx = await browser.newContext(vpOpts);
+  const page = await ctx.newPage();
+
+  page.on('pageerror', err => {
+    console.error(`✗ ${vpName} page error: ${err.message}`);
+    failed++;
+  });
+  page.on('response', resp => {
+    if (resp.status() >= 400) {
+      console.error(`✗ ${vpName} ${resp.status()} ${resp.url()}`);
+      failed++;
+    }
+  });
+
+  for (const route of routes) {
+    const url = BASE + route;
+    const resp = await page.goto(url, { waitUntil: 'networkidle' });
+    if (!resp || !resp.ok()) {
+      console.error(`✗ ${vpName} ${route} status ${resp ? resp.status() : 'no response'}`);
+      failed++;
+      continue;
+    }
+    const slug = route === '/' ? 'home' : route.replace(/^\/|\/$/g, '').replace(/\//g, '-');
+    await page.screenshot({ path: `${outDir}${vpName}-${slug}.png`, fullPage: true });
+    console.log(`✓ ${vpName} ${route}`);
+  }
+
+  await ctx.close();
+}
+
+await browser.close();
+
+if (failed > 0) {
+  console.error(`\n${failed} failure(s).`);
+  process.exit(1);
+}
+console.log('\nAll routes loaded cleanly at all viewports.');


### PR DESCRIPTION
## Summary
- `tests/visual.mjs` — Playwright smoke test that visits each primary route at three viewports (iPhone SE, iPhone 13, desktop). Fails if any page 404s, throws a console error, or any sub-resource returns non-2xx. Writes full-page screenshots to `tests/screenshots/`.
- `.github/workflows/visual.yml` — runs on every PR targeting source. Builds Jekyll, serves `_site` over `python3 -m http.server`, runs the test suite, uploads screenshots as a 14-day artifact named `screenshots-pr-<n>-<run>`.
- Keeps Playwright + Node 22 in `devbox.json` so the same script runs locally: `cd tests && SITE_URL=http://127.0.0.1:4000 node visual.mjs` while a Jekyll server is up.
- `_config.yml` excludes `tests/` from `_site`; `.gitignore` overrides the user's global filter to track `tests/package-lock.json` (needed for `npm ci`).

## Test plan
- [x] `node tests/visual.mjs` passes locally against the dev server (9/9 routes × viewports clean)
- [ ] First-run on CI: the workflow itself runs on this PR — verify it passes and screenshots show up under the "Artifacts" section of the Visual job

## Notes
- Failures show up as PR-level checks; you don't need to merge to find out things broke.
- Screenshots are downloadable from the workflow run page (`Artifacts` panel at the bottom).
- For visual *regression* (diff vs baseline), we'd commit baseline screenshots and add a comparison step. This PR is the smoke-test foundation; happy to add regression later if intentional changes start causing it to nag.