### PR TITLE
Refocus landing on industry, archive academic chapter

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -32,6 +32,12 @@ layout: default
   </div>
 </section>
 
+{% if page.now %}
+<section class="frame" data-label="/now">
+  {{ page.now | markdownify }}
+</section>
+{% endif %}
+
 {% if page.spare_time %}
 <section class="frame" data-label="/spare-time">
   {{ page.spare_time | markdownify }}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -19,12 +19,14 @@ now: |
   reliability, latency, and how to keep the boring parts boring.
 
 spare_time: |
-  Outside work I run a small home lab — a mix of Intel NUCs, Dell
-  mini servers, and an [Oracle Cloud](https://www.oracle.com/cloud/)
-  account — and self-host most of the services I depend on. Home
-  automation is the rabbit hole I keep climbing back into, with
-  [Home Assistant](https://www.home-assistant.io/) at the
-  centerpiece.
+  Outside work I run a small home lab — Intel NUCs and Dell mini
+  servers at home, plus capacity on
+  [Oracle Cloud](https://www.oracle.com/cloud/) and
+  [Hetzner](https://www.hetzner.com/) — and self-host most of the
+  services I depend on. The whole thing is kept reproducible with
+  Terraform and Ansible. Home automation is the rabbit hole I keep
+  climbing back into, with [Home Assistant](https://www.home-assistant.io/)
+  at the centerpiece.
 ---
 
 Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. My academic chapter — embedded systems and cyber-physical co-simulation, the topic of my Ph.D. — is documented over on the [research archive](/publications/).

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -19,11 +19,12 @@ now: |
   reliability, latency, and how to keep the boring parts boring.
 
 spare_time: |
-  Outside work I run a small home lab and self-host most of the
-  services I depend on. Home automation is the rabbit hole I keep
-  climbing back into — [Home Assistant](https://www.home-assistant.io/)
-  is the centerpiece — and I tend to say yes when a project calls
-  for one more Raspberry Pi.
+  Outside work I run a small home lab — a mix of Intel NUCs, Dell
+  mini servers, and an [Oracle Cloud](https://www.oracle.com/cloud/)
+  account — and self-host most of the services I depend on. Home
+  automation is the rabbit hole I keep climbing back into, with
+  [Home Assistant](https://www.home-assistant.io/) at the
+  centerpiece.
 ---
 
 Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. My academic chapter — embedded systems and cyber-physical co-simulation, the topic of my Ph.D. — is documented over on the [research archive](/publications/).

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -9,15 +9,21 @@ profile:
   image: profile.webp
 
 news: true
-selected_papers: true
+selected_papers: false
 social: true
 
+now: |
+  Building backend platforms at [Corsmed](https://corsmed.com) — Go
+  services, distributed systems, and the messy plumbing behind a
+  medical-imaging simulation product. Day-to-day I think about
+  reliability, latency, and how to keep the boring parts boring.
+
 spare_time: |
-  Outside the day job I run a small home lab and self-host most of
-  the services I depend on. Home automation is the rabbit hole I keep
+  Outside work I run a small home lab and self-host most of the
+  services I depend on. Home automation is the rabbit hole I keep
   climbing back into — [Home Assistant](https://www.home-assistant.io/)
   is the centerpiece — and I tend to say yes when a project calls
   for one more Raspberry Pi.
 ---
 
-Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. Background in embedded and cyber-physical systems — the topic of my Ph.D. — and a soft spot for everything that sits between the edge and the cloud.
+Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. My academic chapter — embedded systems and cyber-physical co-simulation, the topic of my Ph.D. — is documented over on the [research archive](/publications/).


### PR DESCRIPTION
## Summary
The hero already read as industry-focused, but the home then put four academic papers (2018–2020) front and center via `/selected-work`. Visitors got a mixed signal.

- **Drop `/selected-work` from home** (`selected_papers: false` in `_pages/about.md`). The `/publications` page stays fully reachable from the navbar.
- **Add a `/now` frame** with what's actually happening at Corsmed day-to-day. Order on the home is now: hero → `/now` → `/spare-time` → `/news` → `/contact`.
- **Rewrite the closing line of the hero** to link to `/publications/` as a "research archive" — one click from the hero, not landing real estate.
- **Fix `/spare-time` copy**: real stack is Intel NUCs + Dell mini servers + Oracle Cloud, not Raspberry Pi.

## Test plan
- [x] `node tests/visual.mjs` passes locally (9/9 routes × viewports)
- [x] Screenshots manually inspected at iPhone 13 and desktop — both layouts read as industry-first with the research link one click away
- [ ] Visual workflow on this PR uploads the screenshots artifact