### PR TITLE
Drop em-dashes from site copy

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -26,7 +26,7 @@ layout: default
       </div>
 
       {% if site.contact_note %}
-      <p class="hero-motto">&mdash; <em>{{ site.contact_note | strip_newlines | strip }}</em></p>
+      <p class="hero-motto"><em>{{ site.contact_note | strip_newlines | strip }}</em></p>
       {% endif %}
     </div>
   </div>

--- a/_news/announcement_2.md
+++ b/_news/announcement_2.md
@@ -27,6 +27,6 @@ Pug heirloom High Life vinyl swag, single-origin coffee four dollar toast taxide
 leanse locavore. Est anim sapiente leggings Brooklyn ea. Thundercats locavore excepteur veniam eiusmod. Raw denim Truffaut Schlitz, migas sapiente Portland VHS twee Bushwick Marfa typewriter retro id keytar.
 
 > We do not grow absolutely, chronologically. We grow sometimes in one dimension, and not in another, unevenly. We grow partially. We are relative. We are mature in one realm, childish in another.
-> —Anais Nin
+> Anaïs Nin
 
 Fap aliqua qui, scenester pug Echo Park polaroid irony shabby chic ex cardigan church-key Odd Future accusamus. Blog stumptown sartorial squid, gastropub duis aesthetic Truffaut vero. Pinterest tilde twee, odio mumblecore jean shorts lumbersexual. -->

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -13,20 +13,20 @@ selected_papers: false
 social: true
 
 now: |
-  Building backend platforms at [Corsmed](https://corsmed.com) — Go
+  Building backend platforms at [Corsmed](https://corsmed.com). Go
   services, distributed systems, and the messy plumbing behind a
   medical-imaging simulation product. Day-to-day I think about
   reliability, latency, and how to keep the boring parts boring.
 
 spare_time: |
-  Outside work I run a small home lab — Intel NUCs and Dell mini
+  Outside work I run a small home lab. Intel NUCs and Dell mini
   servers at home, plus capacity on
   [Oracle Cloud](https://www.oracle.com/cloud/) and
-  [Hetzner](https://www.hetzner.com/) — and self-host most of the
-  services I depend on. The whole thing is kept reproducible with
-  Terraform and Ansible. Home automation is the rabbit hole I keep
-  climbing back into, with [Home Assistant](https://www.home-assistant.io/)
-  at the centerpiece.
+  [Hetzner](https://www.hetzner.com/), all stitched together to
+  self-host most of the services I depend on. The whole thing is
+  kept reproducible with Terraform and Ansible. Home automation
+  is the rabbit hole I keep climbing back into, with
+  [Home Assistant](https://www.home-assistant.io/) at the centerpiece.
 ---
 
-Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. My academic chapter — embedded systems and cyber-physical co-simulation, the topic of my Ph.D. — is documented over on the [research archive](/publications/).
+Senior Software Engineer at [Corsmed](https://corsmed.com), based in Nice. Backend in Go, building reliable platforms and distributed systems. My academic chapter (embedded systems and cyber-physical co-simulation, the topic of my Ph.D.) is documented over on the [research archive](/publications/).

--- a/_projects/bash-virus.md
+++ b/_projects/bash-virus.md
@@ -1,6 +1,6 @@
 ---
 title: bash-virus
-description: Toy bash virus (no payload) — second assignment for the Malware Analysis & Design course at the University of Verona.
+description: Toy bash virus, no payload. Second assignment for the Malware Analysis & Design course at the University of Verona.
 github: https://github.com/giovanni-liboni/bash-virus
 redirect: https://github.com/giovanni-liboni/bash-virus
 importance: 5

--- a/_projects/cosim20-cpu-cooling.md
+++ b/_projects/cosim20-cpu-cooling.md
@@ -1,6 +1,6 @@
 ---
 title: cosim20-CPU-cooling-system
-description: Reference example for the CoSim20 framework — a CPU cooling system co-simulation case study.
+description: Reference example for the CoSim20 framework: a CPU cooling system co-simulation case study.
 github: https://github.com/giovanni-liboni/cosim20-CPU-cooling-system
 redirect: https://github.com/giovanni-liboni/cosim20-CPU-cooling-system
 importance: 2

--- a/_projects/dnl.md
+++ b/_projects/dnl.md
@@ -1,6 +1,6 @@
 ---
 title: dnl
-description: Distributed Notification Library — small Go library for fan-out notifications across nodes.
+description: Distributed Notification Library. Small Go library for fan-out notifications across nodes.
 github: https://github.com/giovanni-liboni/dnl
 redirect: https://github.com/giovanni-liboni/dnl
 importance: 4

--- a/_projects/python-virus.md
+++ b/_projects/python-virus.md
@@ -1,6 +1,6 @@
 ---
 title: python-virus
-description: Simple polymorphic virus written in Python — Malware Analysis & Design course at the University of Verona.
+description: Simple polymorphic virus written in Python. Malware Analysis & Design course at the University of Verona.
 github: https://github.com/giovanni-liboni/python-virus
 redirect: https://github.com/giovanni-liboni/python-virus
 importance: 6

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -102,7 +102,7 @@ blockquote {
   font-style: italic;
 }
 
-// HR — terminal divider
+// HR: terminal divider
 
 hr {
   border: 0;

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -144,7 +144,7 @@
   50% { opacity: 0; }
 }
 
-// News list — same shape as a publication entry: inline date at the top
+// News list: same shape as a publication entry. Inline date at the top
 // in accent color, body flows below as a block.
 
 .news {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -18,7 +18,7 @@ main {
   padding: 2rem 0 4rem;
 }
 
-// Navbar — terminal-style top line
+// Navbar: terminal-style top line
 
 .nav {
   border-bottom: 1px solid var(--fg-faint);

--- a/blog/index.html
+++ b/blog/index.html
@@ -30,5 +30,5 @@ pagination:
 </ul>
 {% include pagination.html %}
 {% else %}
-<p>Nothing here yet — drafting in the open soon.</p>
+<p>Nothing here yet. Drafting in the open soon.</p>
 {% endif %}


### PR DESCRIPTION
## Summary
Per the user's style rule: never use \`—\` or \`&mdash;\` anywhere in the site's copy. Rewrote every occurrence; replacement chosen per context (commas/colons for short asides, periods for parallel clauses, parentheses for parenthetical phrases). No en-dashes substituted either.

11 files touched. The hero closing line went from "...My academic chapter — embedded systems and cyber-physical co-simulation, the topic of my Ph.D. — is documented on the research archive" to "...My academic chapter (embedded systems and cyber-physical co-simulation, the topic of my Ph.D.) is documented on the research archive". The hero motto dropped its leading \`—\` before the italic line. Project descriptions, the /now and /spare-time copy, and the blog placeholder were rewritten with periods/colons. SCSS comments were updated for consistency (not user-facing).

Also added to memory so I default to this going forward.

## Test plan
- [x] \`grep -rn '—|&mdash;|&#8212;'\` returns nothing across the repo
- [x] \`node tests/visual.mjs\` passes locally (9/9 routes × viewports)
- [ ] Visual workflow artifact looks right on this PR